### PR TITLE
Fixed Bugs for Get Content from netease music api.

### DIFF
--- a/LrcHelper/NeteaseMusic.cs
+++ b/LrcHelper/NeteaseMusic.cs
@@ -19,8 +19,8 @@ namespace ludoux.LrcHelper.NeteaseMusic
             {
                 HttpWebRequest wrGETURL = WebRequest.CreateHttp(sURL);
                 
-                wrGETURL.Referer= "https://music.163.com";
-                wrGETURL.Headers.Set(HttpRequestHeader.Cookie, "appver=1.4.0; os=uwp; osver=10.0.15063.296");
+                //wrGETURL.Referer= "https://music.163.com";
+                //wrGETURL.Headers.Set(HttpRequestHeader.Cookie, "appver=1.4.0; os=uwp; osver=10.0.15063.296");
                 Stream objStream = wrGETURL.GetResponse().GetResponseStream();
                 StreamReader objReader = new StreamReader(objStream);
                 while (sLine != null)


### PR DESCRIPTION
原有设置会导致
sContent 是"{"code":-460,"msg":"Cheating"}"

注释掉设置referred和HttpRequestHeader.Cookie后 测试ID:34274786没有产生问题。
具体是否有其它问题有待测试。